### PR TITLE
Changelog for 1.0.0~pre1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,18 @@
-## Ignition Utils 0.x
+## Ignition Utils 1.x
 
-## Ignition Utils 0.x.x
+## Ignition Utils 1.x.x (20XX-XX-XX)
+
+## Ignition Utils 1.0.0 (2021-XX-XX)
+
+1. Ignition ImplPtr
+    * [Pull request 1](https://github.com/ignitionrobotics/ign-utils/pull/1)
+    * [Pull request 4](https://github.com/ignitionrobotics/ign-utils/pull/4)
+
+1. Vendor CLI11 library inside ignition-utils
+    * [Pull request 2](https://github.com/ignitionrobotics/ign-utils/pull/2)
+
+1. Update warning suppression macros
+    * [Pull request 5](https://github.com/ignitionrobotics/ign-utils/pull/5)
+    * [Pull request 10](https://github.com/ignitionrobotics/ign-utils/pull/10)
+    * [Pull request 11](https://github.com/ignitionrobotics/ign-utils/pull/11)
+


### PR DESCRIPTION
Preparation for a prerelelase; the version number is already `1.0.0~pre1`