### PR TITLE
Add configure.bat script for windows builds

### DIFF
--- a/configure.bat
+++ b/configure.bat
@@ -1,0 +1,24 @@
+
+:: NOTE: This script is only meant to be used as part of the ignition developers' CI system
+:: Users and developers should build and install this library using cmake and Visual Studio
+
+
+:: Install dependencies
+call %win_lib% :install_ign_project ign-cmake ign-cmake2
+
+:: Set configuration variables
+@set build_type=Release
+@if not "%1"=="" set build_type=%1
+@echo Configuring for build type %build_type%
+
+:: Go to the directory that this configure.bat file exists in
+cd /d %~dp0
+
+:: Create a build directory and configure
+md build
+cd build
+cmake .. -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="%WORKSPACE_INSTALL_DIR%" -DCMAKE_BUILD_TYPE="%build_type%" -DBUILD_TESTING:BOOL=False
+:: Note: We disable testing by default. If the intention is for the CI to build and test
+:: this project, then the CI script will turn it back on.
+
+:: If the caller wants to build and/or install, they should do so after calling this script


### PR DESCRIPTION
# 🦟 Bug fix

One potential solution to fixing windows CI for https://github.com/ignitionrobotics/ign-transport/pull/216

## Summary

This package is being added as a dependency of ign-transport in https://github.com/ignitionrobotics/ign-transport/pull/216, but the windows CI is currently failing since it uses the old approach based on `configure.bat`, which requires all ignition dependencies to have a `configure.bat` file as well. Since `ign-utils` uses the new approach to windows CI using colcon instead of `configure.bat` (https://github.com/ignition-tooling/release-tools/pull/367), it doesn't currently have a `configure.bat` file. This pull request represents one possible solution by add this file. An alternative is to update ign-transport to use the newer colcon CI.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
