### PR TITLE
Bump main to 2.0.0~pre1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-utils1 VERSION 1.0.0)
+project(ignition-utils2 VERSION 2.0.0)
 
 #============================================================================
 # Find ignition-cmake
@@ -15,7 +15,7 @@ find_package(ignition-cmake2 2.0.0 REQUIRED)
 # Configure the project
 #============================================================================
 set(c++standard 17)
-ign_configure_project(VERSION_SUFFIX pre2)
+ign_configure_project(VERSION_SUFFIX pre1)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## Ignition Utils 2.x
+
+## Ignition Utils 2.0.0 (20XX-XX-XX)
+
 ## Ignition Utils 1.x
 
 ## Ignition Utils 1.x.x (20XX-XX-XX)


### PR DESCRIPTION
Branch `ign-utils1` has been created for the Edifice release and 1.0.0 released from that.

The `main` branch now corresponds to version 2.0.0~pre1, and nightlies will soon be created from this branch.

https://github.com/ignition-tooling/release-tools/issues/421