### PR TITLE
Add an example program using CLI11

### DIFF
--- a/examples/using_cli/CMakeLists.txt
+++ b/examples/using_cli/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+project(ignition-utils-cli-demo)
+
+# Find the Ignition Libraries used directly by the example
+find_package(ignition-utils1 REQUIRED COMPONENTS cli)
+set(IGN_UTILS_VER ${ignition-utils1_VERSION_MAJOR})
+
+add_executable(${PROJECT_NAME} main.cc)
+target_link_libraries(
+  ${PROJECT_NAME}
+  ignition-utils${IGN_UTILS_VER}::cli
+)

--- a/examples/using_cli/main.cc
+++ b/examples/using_cli/main.cc
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <ignition/utils/cli/CLI.hpp>
+#include <ignition/utils/config.hh>
+
+/* 
+ * At this point, all functionality of CLI11 will be available.
+ * Consult https://github.com/CLIUtils/CLI11 for usage
+ */
+
+//////////////////////////////////////////////////
+int main(int argc, char** argv)
+{
+  CLI::App app{"Using ignition-utils CLI wrapper"};
+
+  app.add_flag_callback("-v,--version", [](){
+      std::cout << IGNITION_UTILS_VERSION_FULL << std::endl;
+      throw CLI::Success();
+  });
+
+  CLI11_PARSE(app, argc, argv);
+}


### PR DESCRIPTION
# 🎉 Add an example program using CLI11

Shows basic usage in CMakeLists to build and link against the CLI11 wrapper in ignition

## Test it

To test with the vendored CLI11 version, build a colcon workspace with ign-utils and ign-cmake with

```
         "-DIGN_UTILS_VENDOR_CLI11:BOOL=ON"
```

and then build the example program.

To test with the system CLI11 version, build a colcon workspace with ign-utils and ign-cmake with 
```
         "-DIGN_UTILS_VENDOR_CLI11:BOOL=ON"
```

and then build the example program.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
