### PR TITLE
Add NeverDestroyed utility class

### DIFF
--- a/include/ignition/utils/NeverDestroyed.hh
+++ b/include/ignition/utils/NeverDestroyed.hh
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <new>
+#include <type_traits>
+#include <utility>
+
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+
+/// Wraps an underlying type T such that its storage is a direct member field
+/// of this object (i.e., without any indirection into the heap), but *unlike*
+/// most member fields T's destructor is never invoked.
+///
+/// This is especially useful for function-local static variables that are not
+/// trivially destructable.  We shouldn't call their destructor at program exit
+/// because of the "indeterminate order of ... destruction" as mentioned in
+/// cppguide's
+/// <a href="https://drake.mit.edu/styleguide/cppguide.html#Static_and_Global_Variables">Static
+/// and Global Variables</a> section, but other solutions to this problem place
+///  the objects on the heap through an indirection.
+///
+/// Compared with other approaches, this mechanism more clearly describes the
+/// intent to readers, avoids "possible leak" warnings from memory-checking
+/// tools, and is probably slightly faster.
+///
+/// Example uses:
+///
+/// The singleton pattern:
+/// @code
+/// class Singleton {
+///  public:
+///   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Singleton)
+///   static Singleton& getInstance() {
+///     static never_destroyed<Singleton> instance;
+///     return instance.access();
+///   }
+///  private:
+///   friend never_destroyed<Singleton>;
+///   Singleton() = default;
+/// };
+/// @endcode
+///
+/// A lookup table, created on demand the first time its needed, and then
+/// reused thereafter:
+/// @code
+/// enum class Foo { kBar, kBaz };
+/// Foo ParseFoo(const std::string& foo_string) {
+///   using Dict = std::unordered_map<std::string, Foo>;
+///   static const drake::never_destroyed<Dict> string_to_enum{
+///     std::initializer_list<Dict::value_type>{
+///       {"bar", Foo::kBar},
+///       {"baz", Foo::kBaz},
+///     }
+///   };
+///   return string_to_enum.access().at(foo_string);
+/// }
+/// @endcode
+///
+/// In cases where computing the static data is more complicated than an
+/// initializer_list, you can use a temporary lambda to populate the value:
+/// @code
+/// const std::vector<double>& GetConstantMagicNumbers() {
+///   static const drake::never_destroyed<std::vector<double>> result{[]() {
+///     std::vector<double> prototype;
+///     std::mt19937 random_generator;
+///     for (int i = 0; i < 10; ++i) {
+///       double new_value = random_generator();
+///       prototype.push_back(new_value);
+///     }
+///     return prototype;
+///   }()};
+///   return result.access();
+/// }
+/// @endcode
+///
+/// Note in particular the `()` after the lambda. That causes it to be invoked.
+//
+// The above examples are repeated in the unit test; keep them in sync.
+template <typename T>
+class never_destroyed {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(never_destroyed)
+
+  /// Passes the constructor arguments along to T using perfect forwarding.
+  template <typename... Args>
+  explicit never_destroyed(Args&&... args) {
+    // Uses "placement new" to construct a `T` in `storage_`.
+    new (&storage_) T(std::forward<Args>(args)...);
+  }
+
+  /// Does nothing.  Guaranteed!
+  ~never_destroyed() = default;
+
+  /// Returns the underlying T reference.
+  T& access() { return *reinterpret_cast<T*>(&storage_); }
+  const T& access() const { return *reinterpret_cast<const T*>(&storage_); }
+
+ private:
+  typename std::aligned_storage<sizeof(T), alignof(T)>::type storage_;
+};
+
+}  // namespace drake

--- a/include/ignition/utils/NeverDestroyed.hh
+++ b/include/ignition/utils/NeverDestroyed.hh
@@ -52,14 +52,16 @@ namespace utils
 ///
 /// The singleton pattern:
 /// @code
-/// class Singleton {
+/// class Singleton
+/// {
 ///  public:
 ///   Singleton(const Singleton&) = delete;
 ///   void operator=(const Singleton&) = delete;
 ///   Singleton(Singleton&&) = delete;
 ///   void operator=(Singleton&&) = delete;
 ///
-///   static Singleton& getInstance() {
+///   static Singleton& getInstance()
+///   {
 ///     static ignition::utils::NeverDestroyed<Singleton> instance;
 ///     return instance.access();
 ///   }
@@ -73,10 +75,13 @@ namespace utils
 /// reused thereafter:
 /// @code
 /// enum class Foo { kBar, kBaz };
-/// Foo ParseFoo(const std::string& foo_string) {
+/// Foo ParseFoo(const std::string& foo_string)
+/// {
 ///   using Dict = std::unordered_map<std::string, Foo>;
-///   static const ignition::utils::NeverDestroyed<Dict> string_to_enum{
-///     std::initializer_list<Dict::value_type>{
+///   static const ignition::utils::NeverDestroyed<Dict> string_to_enum
+///   {
+///     std::initializer_list<Dict::value_type>
+///     {
 ///       {"bar", Foo::kBar},
 ///       {"baz", Foo::kBaz},
 ///     }
@@ -88,17 +93,22 @@ namespace utils
 /// In cases where computing the static data is more complicated than an
 /// initializer_list, you can use a temporary lambda to populate the value:
 /// @code
-/// const std::vector<double>& GetConstantMagicNumbers() {
-///   static const ignition::utils::NeverDestroyed<std::vector<double>> result{
-///   []() {
+/// const std::vector<double>& GetConstantMagicNumbers()
+/// {
+///   static const ignition::utils::NeverDestroyed<std::vector<double>> result
+///   {
+///   []()
+///   {
 ///     std::vector<double> prototype;
 ///     std::mt19937 random_generator;
-///     for (int i = 0; i < 10; ++i) {
+///     for (int i = 0; i < 10; ++i)
+///     {
 ///       double new_value = random_generator();
 ///       prototype.push_back(new_value);
 ///     }
 ///     return prototype;
-///   }()};
+///   }()
+///   };
 ///   return result.access();
 /// }
 /// @endcode
@@ -107,47 +117,46 @@ namespace utils
 //
 // The above examples are repeated in the unit test; keep them in sync.
 template <typename T>
-class NeverDestroyed {
- public:
+class NeverDestroyed
+{
   /// Passes the constructor arguments along to T using perfect forwarding.
-  template <typename... Args>
-  explicit NeverDestroyed(Args&&... args) {
+  public: template <typename... Args>
+          explicit NeverDestroyed(Args &&... args)
+  {
     // Uses "placement new" to construct a `T` in `storage_`.
     new (&this->storage) T(std::forward<Args>(args)...);
   }
 
   /// Does nothing.  Guaranteed!
-  ~NeverDestroyed() = default;
+  public: ~NeverDestroyed() = default;
 
   /// \brief Deleted copy constructor
-  NeverDestroyed(const NeverDestroyed&) = delete;
+  public: NeverDestroyed(const NeverDestroyed &) = delete;
 
   /// \brief Deleted move constructor
-  NeverDestroyed(NeverDestroyed&&) = delete;
+  public: NeverDestroyed(NeverDestroyed &&) = delete;
 
   /// \brief Deleted copy assignment constructor
-  NeverDestroyed& operator=(const NeverDestroyed&) = delete;
+  public: NeverDestroyed &operator=(const NeverDestroyed &) = delete;
 
   /// \brief Deleted move assignment constructor
-  NeverDestroyed& operator=(NeverDestroyed&&) noexcept = delete;
+  public: NeverDestroyed &operator=(NeverDestroyed &&) noexcept = delete;
 
   /// Returns the underlying T reference.
-  T& Access()
+  public: T &Access()
   {
-    return *reinterpret_cast<T*>(&this->storage);
+    return *reinterpret_cast<T *>(&this->storage);
   }
 
-  const T& Access() const
+  public: const T &Access() const
   {
-    return *reinterpret_cast<const T*>(&this->storage);
+    return *reinterpret_cast<const T *>(&this->storage);
   }
 
- private:
-  typename std::aligned_storage<sizeof(T), alignof(T)>::type storage;
+  private: typename std::aligned_storage<sizeof(T), alignof(T)>::type storage;
 };
 
 }  // namespace utils
 }  // namespace ignition
 
 #endif  // IGNITION_UTILS_NEVERDESTROYED_HH_
-

--- a/include/ignition/utils/NeverDestroyed.hh
+++ b/include/ignition/utils/NeverDestroyed.hh
@@ -29,7 +29,7 @@ namespace utils
 
 /// Originally copied from https://github.com/RobotLocomotion/drake/blob/v0.36.0/common/never_destroyed.h
 /// Originally licensed BSD 3-Clause (https://github.com/RobotLocomotion/drake/blob/v0.36.0/LICENSE.TXT)
-/// Re-licensed Apache-2.0 with permission from: 
+/// Re-licensed Apache-2.0 with permission from:
 /// @jwnimmer-tri (https://github.com/ignitionrobotics/ign-utils/pull/31#issuecomment-989173512)
 ///
 /// Wraps an underlying type T such that its storage is a direct member field

--- a/include/ignition/utils/NeverDestroyed.hh
+++ b/include/ignition/utils/NeverDestroyed.hh
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 #ifndef IGNITION_UTILS_NEVERDESTROYED_HH_
 #define IGNITION_UTILS_NEVERDESTROYED_HH_
 
@@ -12,7 +29,9 @@ namespace utils
 
 /// Originally copied from https://github.com/RobotLocomotion/drake/blob/v0.36.0/common/never_destroyed.h
 /// Originally licensed BSD 3-Clause (https://github.com/RobotLocomotion/drake/blob/v0.36.0/LICENSE.TXT)
-
+/// Re-licensed Apache-2.0 with permission from: 
+/// @jwnimmer-tri (https://github.com/ignitionrobotics/ign-utils/pull/31#issuecomment-989173512)
+///
 /// Wraps an underlying type T such that its storage is a direct member field
 /// of this object (i.e., without any indirection into the heap), but *unlike*
 /// most member fields T's destructor is never invoked.
@@ -21,13 +40,72 @@ namespace utils
 /// trivially destructable.  We shouldn't call their destructor at program exit
 /// because of the "indeterminate order of ... destruction" as mentioned in
 /// cppguide's
-/// <a href="https://drake.mit.edu/styleguide/cppguide.html#Static_and_Global_Variables">Static
+/// <a href="https://google.github.io/styleguide/cppguide.html#Static_and_Global_Variables">Static
 /// and Global Variables</a> section, but other solutions to this problem place
 ///  the objects on the heap through an indirection.
 ///
 /// Compared with other approaches, this mechanism more clearly describes the
 /// intent to readers, avoids "possible leak" warnings from memory-checking
 /// tools, and is probably slightly faster.
+///
+/// Example uses:
+///
+/// The singleton pattern:
+/// @code
+/// class Singleton {
+///  public:
+///   Singleton(const Singleton&) = delete;
+///   void operator=(const Singleton&) = delete;
+///   Singleton(Singleton&&) = delete;
+///   void operator=(Singleton&&) = delete;
+///
+///   static Singleton& getInstance() {
+///     static ignition::utils::NeverDestroyed<Singleton> instance;
+///     return instance.access();
+///   }
+///  private:
+///   friend ignition::utils::NeverDestroyed<Singleton>;
+///   Singleton() = default;
+/// };
+/// @endcode
+///
+/// A lookup table, created on demand the first time its needed, and then
+/// reused thereafter:
+/// @code
+/// enum class Foo { kBar, kBaz };
+/// Foo ParseFoo(const std::string& foo_string) {
+///   using Dict = std::unordered_map<std::string, Foo>;
+///   static const ignition::utils::NeverDestroyed<Dict> string_to_enum{
+///     std::initializer_list<Dict::value_type>{
+///       {"bar", Foo::kBar},
+///       {"baz", Foo::kBaz},
+///     }
+///   };
+///   return string_to_enum.access().at(foo_string);
+/// }
+/// @endcode
+///
+/// In cases where computing the static data is more complicated than an
+/// initializer_list, you can use a temporary lambda to populate the value:
+/// @code
+/// const std::vector<double>& GetConstantMagicNumbers() {
+///   static const ignition::utils::NeverDestroyed<std::vector<double>> result{
+///   []() {
+///     std::vector<double> prototype;
+///     std::mt19937 random_generator;
+///     for (int i = 0; i < 10; ++i) {
+///       double new_value = random_generator();
+///       prototype.push_back(new_value);
+///     }
+///     return prototype;
+///   }()};
+///   return result.access();
+/// }
+/// @endcode
+///
+/// Note in particular the `()` after the lambda. That causes it to be invoked.
+//
+// The above examples are repeated in the unit test; keep them in sync.
 template <typename T>
 class NeverDestroyed {
  public:
@@ -35,7 +113,7 @@ class NeverDestroyed {
   template <typename... Args>
   explicit NeverDestroyed(Args&&... args) {
     // Uses "placement new" to construct a `T` in `storage_`.
-    new (&storage_) T(std::forward<Args>(args)...);
+    new (&this->storage) T(std::forward<Args>(args)...);
   }
 
   /// Does nothing.  Guaranteed!
@@ -54,11 +132,18 @@ class NeverDestroyed {
   NeverDestroyed& operator=(NeverDestroyed&&) noexcept = delete;
 
   /// Returns the underlying T reference.
-  T& access() { return *reinterpret_cast<T*>(&storage_); }
-  const T& access() const { return *reinterpret_cast<const T*>(&storage_); }
+  T& Access()
+  {
+    return *reinterpret_cast<T*>(&this->storage);
+  }
+
+  const T& Access() const
+  {
+    return *reinterpret_cast<const T*>(&this->storage);
+  }
 
  private:
-  typename std::aligned_storage<sizeof(T), alignof(T)>::type storage_;
+  typename std::aligned_storage<sizeof(T), alignof(T)>::type storage;
 };
 
 }  // namespace utils

--- a/src/NeverDestroyed_TEST.cc
+++ b/src/NeverDestroyed_TEST.cc
@@ -1,0 +1,98 @@
+#include "drake/common/never_destroyed.h"
+
+#include <random>
+#include <unordered_map>
+
+#include <gtest/gtest.h>
+
+#include "drake/common/drake_copyable.h"
+
+namespace drake {
+namespace {
+
+class Boom : public std::exception { };
+struct DtorGoesBoom {
+  ~DtorGoesBoom() noexcept(false) { throw Boom(); }
+};
+
+// Confirm that we see booms by default.
+GTEST_TEST(NeverDestroyedTest, BoomTest) {
+  try {
+    { DtorGoesBoom foo; }
+    GTEST_FAIL();
+  } catch (const Boom&) {
+    ASSERT_TRUE(true);
+  }
+}
+
+// Confirm that our wrapper stops the booms.
+GTEST_TEST(NeverDestroyedTest, NoBoomTest) {
+  try {
+    { never_destroyed<DtorGoesBoom> foo; }
+    ASSERT_TRUE(true);
+  } catch (const Boom& e) {
+    GTEST_FAIL();
+  }
+}
+
+// This is an example from the class overview API docs; we repeat it here to
+// ensure it remains valid.
+class Singleton {
+ public:
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(Singleton)
+  static Singleton& getInstance() {
+    static never_destroyed<Singleton> instance;
+    return instance.access();
+  }
+ private:
+  friend never_destroyed<Singleton>;
+  Singleton() = default;
+};
+
+GTEST_TEST(NeverDestroyedExampleTest, Singleton) {
+  const Singleton* get1 = &Singleton::getInstance();
+  const Singleton* get2 = &Singleton::getInstance();
+  EXPECT_EQ(get1, get2);
+}
+
+// This is an example from the class overview API docs; we repeat it here to
+// ensure it remains valid.
+enum class Foo { kBar, kBaz };
+Foo ParseFoo(const std::string& foo_string) {
+  using Dict = std::unordered_map<std::string, Foo>;
+  static const drake::never_destroyed<Dict> string_to_enum{
+    std::initializer_list<Dict::value_type>{
+      {"bar", Foo::kBar},
+      {"baz", Foo::kBaz},
+    }
+  };
+  return string_to_enum.access().at(foo_string);
+}
+
+GTEST_TEST(NeverDestroyedExampleTest, ParseFoo) {
+  EXPECT_EQ(ParseFoo("bar"), Foo::kBar);
+  EXPECT_EQ(ParseFoo("baz"), Foo::kBaz);
+}
+
+// This is an example from the class overview API docs; we repeat it here to
+// ensure it remains valid.
+const std::vector<double>& GetConstantMagicNumbers() {
+  static const drake::never_destroyed<std::vector<double>> result{[]() {
+    std::vector<double> prototype;
+    std::mt19937 random_generator;
+    for (int i = 0; i < 10; ++i) {
+      double new_value = random_generator();
+      prototype.push_back(new_value);
+    }
+    return prototype;
+  }()};
+  return result.access();
+}
+
+GTEST_TEST(NeverDestroyedExampleTest, GetConstantMagicNumbers) {
+  const auto& numbers = GetConstantMagicNumbers();
+  EXPECT_EQ(numbers.size(), 10);
+}
+
+}  // namespace
+}  // namespace drake

--- a/src/NeverDestroyed_TEST.cc
+++ b/src/NeverDestroyed_TEST.cc
@@ -15,106 +15,134 @@
  *
  */
 
+#include "ignition/utils/NeverDestroyed.hh"
+
 #include <gtest/gtest.h>
 
 #include <random>
 #include <unordered_map>
 
-#include "ignition/utils/NeverDestroyed.hh"
-
-class Boom : public std::exception { };
-struct DtorGoesBoom {
+class Boom : public std::exception
+{
+};
+struct DtorGoesBoom
+{
 #ifdef _WIN32
 // Disable warning C4722 which is triggered by the exception thrown in the dtor
 #pragma warning(push)
 #pragma warning(disable : 4722)
 #endif
-  ~DtorGoesBoom() noexcept(false) { throw Boom(); }
+  ~DtorGoesBoom() noexcept(false)
+  {
+    throw Boom();
+  }
 #ifdef _WIN32
 #pragma warning(pop)
 #endif
 };
 
 // Confirm that we see booms by default.
-GTEST_TEST(NeverDestroyed, BoomTest) {
-  try {
-    { DtorGoesBoom foo; }
+GTEST_TEST(NeverDestroyed, BoomTest)
+{
+  try
+  {
+    {
+      DtorGoesBoom foo;
+    }
     GTEST_FAIL();
-  } catch (const Boom&) {
+  }
+  catch (const Boom &)
+  {
     ASSERT_TRUE(true);
   }
 }
 
 // Confirm that our wrapper stops the booms.
-GTEST_TEST(NeverDestroyed, NoBoomTest) {
-  try {
-    { ignition::utils::NeverDestroyed<DtorGoesBoom> foo; }
+GTEST_TEST(NeverDestroyed, NoBoomTest)
+{
+  try
+  {
+    {
+      ignition::utils::NeverDestroyed<DtorGoesBoom> foo;
+    }
     ASSERT_TRUE(true);
-  } catch (const Boom& e) {
+  }
+  catch (const Boom &e)
+  {
     GTEST_FAIL();
   }
 }
 
 // This is an example from the class overview API docs; we repeat it here to
 // ensure it remains valid.
-class Singleton {
- public:
-  Singleton(const Singleton&) = delete;
-  void operator=(const Singleton&) = delete;
-  Singleton(Singleton&&) = delete;
-  void operator=(Singleton&&) = delete;
-
-  static Singleton& getInstance() {
+class Singleton
+{
+  public: Singleton(const Singleton &) = delete;
+  public: void operator=(const Singleton &) = delete;
+  public: Singleton(Singleton &&) = delete;
+  public: void operator=(Singleton &&) = delete;
+  public: static Singleton &getInstance()
+  {
     static ignition::utils::NeverDestroyed<Singleton> instance;
     return instance.Access();
   }
- private:
-  friend ignition::utils::NeverDestroyed<Singleton>;
-  Singleton() = default;
+
+  private: friend ignition::utils::NeverDestroyed<Singleton>;
+  private: Singleton() = default;
 };
 
-GTEST_TEST(NeverDestroyedExample, Singleton) {
-  const Singleton* get1 = &Singleton::getInstance();
-  const Singleton* get2 = &Singleton::getInstance();
+GTEST_TEST(NeverDestroyedExample, Singleton)
+{
+  const Singleton *get1 = &Singleton::getInstance();
+  const Singleton *get2 = &Singleton::getInstance();
   EXPECT_EQ(get1, get2);
 }
 
 // This is an example from the class overview API docs; we repeat it here to
 // ensure it remains valid.
-enum class Foo { kBar, kBaz };
-Foo ParseFoo(const std::string& foo_string) {
+enum class Foo
+{
+  kBar,
+  kBaz
+};
+Foo ParseFoo(const std::string &foo_string)
+{
   using Dict = std::unordered_map<std::string, Foo>;
   static const ignition::utils::NeverDestroyed<Dict> string_to_enum{
-    std::initializer_list<Dict::value_type>{
-      {"bar", Foo::kBar},
-      {"baz", Foo::kBaz},
-    }
-  };
+      std::initializer_list<Dict::value_type>{
+          {"bar", Foo::kBar},
+          {"baz", Foo::kBaz},
+      }};
   return string_to_enum.Access().at(foo_string);
 }
 
-GTEST_TEST(NeverDestroyedExample, ParseFoo) {
+GTEST_TEST(NeverDestroyedExample, ParseFoo)
+{
   EXPECT_EQ(ParseFoo("bar"), Foo::kBar);
   EXPECT_EQ(ParseFoo("baz"), Foo::kBaz);
 }
 
 // This is an example from the class overview API docs; we repeat it here to
 // ensure it remains valid.
-const std::vector<double>& GetConstantMagicNumbers() {
-  static const
-  ignition::utils::NeverDestroyed<std::vector<double>> result{[]() {
-    std::vector<double> prototype;
-    std::mt19937 random_generator;
-    for (int i = 0; i < 10; ++i) {
-      double new_value = random_generator();
-      prototype.push_back(new_value);
-    }
-    return prototype;
-  }()};
+const std::vector<double> &GetConstantMagicNumbers()
+{
+  static const ignition::utils::NeverDestroyed<std::vector<double>> result{
+      []()
+      {
+        std::vector<double> prototype;
+        std::mt19937 random_generator;
+        for (int i = 0; i < 10; ++i)
+        {
+          double new_value = random_generator();
+          prototype.push_back(new_value);
+        }
+        return prototype;
+      }()};
   return result.Access();
 }
 
-GTEST_TEST(NeverDestroyedExample, GetConstantMagicNumbers) {
-  const auto& numbers = GetConstantMagicNumbers();
+GTEST_TEST(NeverDestroyedExample, GetConstantMagicNumbers)
+{
+  const auto &numbers = GetConstantMagicNumbers();
   EXPECT_EQ(numbers.size(), 10u);
 }

--- a/src/NeverDestroyed_TEST.cc
+++ b/src/NeverDestroyed_TEST.cc
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 #include <gtest/gtest.h>
 
 #include <random>

--- a/src/NeverDestroyed_TEST.cc
+++ b/src/NeverDestroyed_TEST.cc
@@ -7,7 +7,15 @@
 
 class Boom : public std::exception { };
 struct DtorGoesBoom {
+#ifdef _WIN32
+// Disable warning C4722 which is triggered by the exception thrown in the dtor
+#pragma warning(push)
+#pragma warning(disable : 4722)
+#endif
   ~DtorGoesBoom() noexcept(false) { throw Boom(); }
+#ifdef _WIN32
+#pragma warning(pop)
+#endif
 };
 
 // Confirm that we see booms by default.

--- a/src/NeverDestroyed_TEST.cc
+++ b/src/NeverDestroyed_TEST.cc
@@ -49,7 +49,7 @@ class Singleton {
 
   static Singleton& getInstance() {
     static ignition::utils::NeverDestroyed<Singleton> instance;
-    return instance.access();
+    return instance.Access();
   }
  private:
   friend ignition::utils::NeverDestroyed<Singleton>;
@@ -73,7 +73,7 @@ Foo ParseFoo(const std::string& foo_string) {
       {"baz", Foo::kBaz},
     }
   };
-  return string_to_enum.access().at(foo_string);
+  return string_to_enum.Access().at(foo_string);
 }
 
 GTEST_TEST(NeverDestroyedExample, ParseFoo) {
@@ -94,7 +94,7 @@ const std::vector<double>& GetConstantMagicNumbers() {
     }
     return prototype;
   }()};
-  return result.access();
+  return result.Access();
 }
 
 GTEST_TEST(NeverDestroyedExample, GetConstantMagicNumbers) {


### PR DESCRIPTION
# 🎉 New feature

## Summary

Useful for function-local static variables that are not trivially destructable.  This can be used to clean up "possible leak" warnings from memory-checking tools.

Originally imported from drake codebase (BSD 3-clause).  It has been updated for consistency with ignition codebase.

Added in support of https://github.com/ignitionrobotics/ign-math/issues/269 at the suggestion of @jwnimmer-tri (https://github.com/ignitionrobotics/ign-math/issues/269#issuecomment-975809753)

## Test it

Unit tests have been imported as well

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
