### PR TITLE
Fix inline namespace issue with clang6

### DIFF
--- a/src/Environment.cc
+++ b/src/Environment.cc
@@ -20,10 +20,15 @@
 #include <cstdlib>
 #include <iostream>
 
+
+namespace ignition
+{
+namespace utils
+{
+inline namespace IGNITION_UTILS_VERSION_NAMESPACE {
+
 /////////////////////////////////////////////////
-bool ignition::utils::env(const std::string &_name,
-                          std::string &_value,
-                          bool _allowEmpty)
+bool env(const std::string &_name, std::string &_value, bool _allowEmpty)
 {
 #ifdef _WIN32
   size_t requiredSize;
@@ -62,8 +67,7 @@ bool ignition::utils::env(const std::string &_name,
 }
 
 /////////////////////////////////////////////////
-bool ignition::utils::setenv(const std::string &_name,
-                             const std::string &_value)
+bool setenv(const std::string &_name, const std::string &_value)
 {
 #ifdef _WIN32
   if (0 != _putenv_s(_name.c_str(), _value.c_str()))
@@ -80,7 +84,7 @@ bool ignition::utils::setenv(const std::string &_name,
 }
 
 /////////////////////////////////////////////////
-bool ignition::utils::unsetenv(const std::string &_name)
+bool unsetenv(const std::string &_name)
 {
 #ifdef _WIN32
   if (0 != _putenv_s(_name.c_str(), ""))
@@ -94,4 +98,7 @@ bool ignition::utils::unsetenv(const std::string &_name)
   }
 #endif
   return true;
+}
+}
+}
 }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #36

## Summary
For some reason clang6 doesn't pick up the inline namespace when defining functions with their fully qualified name (sans the inline namespace). This fixes the issue by defining the functions inside the inline namespace.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.