### PR TITLE
Remove Bionic from future releases (Garden+)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,17 +3,6 @@ name: Ubuntu CI
 on: [push, pull_request]
 
 jobs:
-  bionic-ci:
-    runs-on: ubuntu-latest
-    name: Ubuntu Bionic CI
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Compile and test
-        id: ci
-        uses: ignition-tooling/action-ignition-ci@bionic
-        with:
-          codecov-enabled: true
   focal-ci:
     runs-on: ubuntu-latest
     name: Ubuntu Focal CI
@@ -24,7 +13,8 @@ jobs:
         id: ci
         uses: ignition-tooling/action-ignition-ci@focal
         with:
-          enable-cpplint: true
+          codecov-enabled: true
+          cpplint-enabled: true
   jammy-ci:
     runs-on: ubuntu-latest
     name: Ubuntu Jammy CI

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Build | Status
 -- | --
 Test coverage | [![codecov](https://codecov.io/gh/ignitionrobotics/ign-utils/branch/main/graph/badge.svg)](https://codecov.io/gh/ignitionrobotics/ign-utils)
-Ubuntu Bionic | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_utils-ci-main-bionic-amd64)](https://build.osrfoundation.org/job/ignition_utils-ci-main-bionic-amd64)
+Ubuntu Focal | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_utils-ci-main-focal-amd64)](https://build.osrfoundation.org/job/ignition_utils-ci-main-focal-amd64)
 Homebrew      | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_utils-ci-main-homebrew-amd64)](https://build.osrfoundation.org/job/ignition_utils-ci-main-homebrew-amd64)
 Windows       | [![Build Status](https://build.osrfoundation.org/job/ign_utils-ci-win/badge/icon)](https://build.osrfoundation.org/job/ign_utils-ci-win/)
 

--- a/tutorials/installation.md
+++ b/tutorials/installation.md
@@ -53,7 +53,12 @@ necessary prerequisites followed by building from source.
 
 ### Building from source
 
-1. Clone the repository
+1. Install tools
+  ```
+  sudo apt install -y build-essential cmake git gnupg lsb-release wget
+  ```
+
+2. Clone the repository
 
     ```
     git clone https://github.com/ignitionrobotics/ign-utils -b ign-utils<#>
@@ -61,21 +66,20 @@ necessary prerequisites followed by building from source.
     Be sure to replace `<#>` with a number value, such as 1 or 2, depending on
     which version you need.
 
-2. Install dependencies
+3. Install dependencies
 
     ```
-    export SYSTEM_VERSION=bionic
     sudo apt -y install \
-      $(sort -u $(find . -iname 'packages-'$SYSTEM_VERSION'.apt' -o -iname 'packages.apt') | tr '\n' ' ')
+      $(sort -u $(find . -iname 'packages-'`lsb_release -cs`'.apt' -o -iname 'packages.apt' | tr '\n' ' '))
     ```
 
-3. Configure and build
+4. Configure and build
 
     ```
     cd ign-utils; mkdir build; cd build; cmake ..; make
     ```
 
-4. Optionally, install Ignition Utils
+5. Optionally, install Ignition Utils
 
     ```
     sudo make install


### PR DESCRIPTION
* See https://github.com/ignition-tooling/release-tools/issues/597

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

There are no plans to include `ign-utils2` on Garden, but whenever it's officially released, it won't have Bionic support.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

No Bionic builds should be triggered.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
