### PR TITLE
Improvements to enable "-Wconversion"

### DIFF
--- a/src/NeverDestroyed_TEST.cc
+++ b/src/NeverDestroyed_TEST.cc
@@ -124,16 +124,17 @@ GTEST_TEST(NeverDestroyedExample, ParseFoo)
 
 // This is an example from the class overview API docs; we repeat it here to
 // ensure it remains valid.
-const std::vector<double> &GetConstantMagicNumbers()
+using Result = std::vector<std::uint_fast32_t>;
+const Result &GetConstantMagicNumbers()
 {
-  static const ignition::utils::NeverDestroyed<std::vector<double>> result{
+  static const ignition::utils::NeverDestroyed<Result> result{
       []()
       {
-        std::vector<double> prototype;
+        Result prototype;
         std::mt19937 random_generator;
         for (int i = 0; i < 10; ++i)
         {
-          double new_value = random_generator();
+          auto new_value = random_generator();
           prototype.push_back(new_value);
         }
         return prototype;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,15 +1,17 @@
-include_directories (
-  ${PROJECT_SOURCE_DIR}/test/gtest/include
-  ${PROJECT_SOURCE_DIR}/test/gtest
-  ${PROJECT_SOURCE_DIR}/test
-  ${CMAKE_BINARY_DIR}/include
-)
-
 configure_file (test_config.h.in ${PROJECT_BINARY_DIR}/test_config.h)
+include_directories (
+  ${PROJECT_BINARY_DIR}/include
+)
 
 # Build gtest
 add_library(gtest STATIC gtest/src/gtest-all.cc)
 add_library(gtest_main STATIC gtest/src/gtest_main.cc)
+target_include_directories(gtest 
+  SYSTEM PUBLIC
+  ${PROJECT_SOURCE_DIR}/test/gtest/include
+  ${PROJECT_SOURCE_DIR}/test/gtest
+)
+
 target_link_libraries(gtest_main gtest)
 set_property(TARGET gtest_main PROPERTY CXX_STANDARD ${c++standard})
 set_property(TARGET gtest PROPERTY CXX_STANDARD ${c++standard})
@@ -18,7 +20,6 @@ set(GTEST_MAIN_LIBRARY "${PROJECT_BINARY_DIR}/test/libgtest_main.a")
 
 execute_process(COMMAND cmake -E remove_directory ${CMAKE_BINARY_DIR}/test_results)
 execute_process(COMMAND cmake -E make_directory ${CMAKE_BINARY_DIR}/test_results)
-include_directories(${GTEST_INCLUDE_DIRS})
 
 #============================================================================
 # Do a fake install of ign-utils in order to test the examples.


### PR DESCRIPTION
I noticed that Windows is more strict about conversions.

It would be nice to turn on "-Wconversion" up the stack, but gcc is even _more_ strict about conversions.  This is a step in fixing that.